### PR TITLE
Pasteboard for binary support on MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test_macos_clipboard:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
           architecture: 'x64'
 
       - name: install
-        run: python -m pip install --upgrade . && python -m pip install pytest coverage coveralls
+        run: python -m pip install --upgrade . && python -m pip install pytest coverage coveralls && pip install pasteboard --no-use-pep517
 
       - name: run tests
         env: # Or as an environment variable

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
           architecture: 'x64'
 
       - name: install
-        run: python -m pip install --upgrade . && python -m pip install pytest coverage coveralls && pip install pasteboard --no-use-pep517
+        run: python -m pip install --upgrade . && python -m pip install pytest coverage coveralls && pip install "pasteboard<0.3.2" --no-use-pep517
 
       - name: run tests
         env: # Or as an environment variable

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Requires python 3.7+
 pip install pyperclip3
 ```
 
+On MacOS it's recommended to install the optional `pasteboard` package for 
+binary support.
+
+```bash
+pip install "pyperclip3[pasteboard]" --no-use-pep517
+```
+
 ## Usage
 
 pyperclip3 can be used in Python code

--- a/README.md
+++ b/README.md
@@ -64,7 +64,17 @@ If there is a platform or utility not currently listed, please request it by cre
 
 ### MacOS
 
-There is a known issue that `pbcopy`/`pbpaste` do not support arbitrary binary data.
+MacOS has support for multiple backends.
+
+For full support on MacOS, the `pasteboard` package needs to be installed. 
+This is the default backend when available. You can install this as an extra:
+
+```
+pip install pyperclip3[pasteboard] --no-use-pep517
+```
+
+As a fallback, `pbcopy`/`pbpaste` can be used as a backend, but do not support arbitrary binary data, which may lead to 
+data being lost on copy/paste.
 
 ### Linux
 

--- a/pyperclip3/base.py
+++ b/pyperclip3/base.py
@@ -24,16 +24,12 @@ class ClipboardSetupException(ClipboardException):
 class ClipboardBase(ABC):
     @abstractmethod
     def copy(self, data: Union[str, bytes], encoding=None):
-        return NotImplemented
+        return NotImplemented  # pragma: no cover
 
     @abstractmethod
     def paste(self, encoding=None, text=None, errors=None) -> Union[str, bytes]:
-        return NotImplemented
+        return NotImplemented  # pragma: no cover
 
     @abstractmethod
     def clear(self):
-        return NotImplemented
-
-    @property
-    def type(self):
-        return self.__class__.__name__
+        return NotImplemented  # pragma: no cover

--- a/pyperclip3/cli.py
+++ b/pyperclip3/cli.py
@@ -18,7 +18,7 @@ import sys
 def _main(args):
     from pyperclip3 import copy, clear, paste
     if args.command == "copy":
-        copy(sys.stdin.read())
+        copy(sys.stdin.buffer.read())
     elif args.command == 'paste':
         sys.stdout.buffer.write(paste())
     elif args.command == 'clear':

--- a/pyperclip3/macos_clip.py
+++ b/pyperclip3/macos_clip.py
@@ -94,11 +94,11 @@ class _PasteboardBackend(ClipboardBase):
 
     def copy(self, data: Union[str, bytes], encoding=None):
         if isinstance(data, bytes):
-            if encoding is not None:
-                warnings.warn("encoding specified with a bytes argument. "
-                              "Encoding option will be ignored. "
-                              "To remove this warning, omit the encoding parameter or specify it as None", stacklevel=2)
-            self.pb.set_contents(data, self._bytes_type)
+            try:
+                data = data.decode()
+                self.pb.set_contents(data)
+            except UnicodeDecodeError:
+                self.pb.set_contents(data, self._bytes_type)
         elif isinstance(data, str):
             self.pb.set_contents(data)
         else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup
 from io import open
 import sys
 test_requirements = ['pytest']
-extras = {'test': test_requirements}
+extras = {'test': test_requirements,
+          'pasteboard': ['pasteboard < 0.3.2']}
 
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
@@ -22,6 +23,7 @@ setup(
     install_requires=[
         'pywin32 >= 1.0 ; platform_system=="Windows"',
     ],
+    extras_require=extras,
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python',

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -21,7 +21,7 @@ def test_copypaste_unicode():
     assert clip.paste().decode() == unicode
 
 
-@pytest.mark.xfail(sys.platform == 'darwin', reason="MacOS doesn't yet support arbitrary data", strict=True)
+@pytest.mark.xfail(sys.platform == 'darwin', reason="MacOS doesn't yet support arbitrary data")
 def test_copy_paste_arbitrary_data():
     import secrets
     randbytes = secrets.token_bytes(1024)
@@ -29,6 +29,37 @@ def test_copy_paste_arbitrary_data():
     assert clip.paste() == randbytes
 
 def test_clear():
+    clip.copy('foo')
+    assert clip.paste(), 'test setup failed; clipboard contents unexpectedly empty'
+    clip.clear()
+    data = clip.paste()
+    assert not data, f'clipboard contents unexpectly present: {repr(data)}'
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason='This test is for MacOS only')
+def test_copypaste_pbcopy_backend():
+    from pyperclip3.macos_clip import _PBCopyPBPasteBackend, MacOSClip
+    backend = _PBCopyPBPasteBackend()
+    clip = MacOSClip(_backend=backend)
+    clip.copy('foo')
+    assert clip.paste()
+    assert clip.paste() == b'foo'
+    assert clip.paste(text=True) == 'foo'
+@pytest.mark.skipif(sys.platform != 'darwin', reason='This test is for MacOS only')
+def test_copypaste_unicode_pbcopy_backend():
+    from pyperclip3.macos_clip import _PBCopyPBPasteBackend, MacOSClip
+    backend = _PBCopyPBPasteBackend()
+    clip = MacOSClip(_backend=backend)
+    unicode = 'א ב ג ד ה ו ז ח ט י ך כ ל ם מ ן נ ס ע ף פ ץ צ ק ר ש ת װ ױ'
+    clip.copy(unicode)
+    assert clip.paste().decode() == unicode
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason='This test is for MacOS only')
+def test_clear_pbcopy_backend():
+    from pyperclip3.macos_clip import _PBCopyPBPasteBackend, MacOSClip
+    backend = _PBCopyPBPasteBackend()
+    clip = MacOSClip(_backend=backend)
     clip.copy('foo')
     assert clip.paste(), 'test setup failed; clipboard contents unexpectedly empty'
     clip.clear()


### PR DESCRIPTION
Adds a new backend for MacOS using `pasteboard`.

Falls back to `pbcopy`/`pbpaste` if not present.