### PR TITLE
allow pasting arbitrary binary content in xclip

### DIFF
--- a/pyclip/xclip_clip.py
+++ b/pyclip/xclip_clip.py
@@ -14,12 +14,12 @@
 """
 Provides the clipboard functionality for Linux via ``xclip``
 """
-import warnings
-
-from .base import ClipboardBase, ClipboardSetupException, ClipboardException
-from typing import Union
 import shutil
 import subprocess
+import warnings
+from typing import Union
+
+from .base import ClipboardBase, ClipboardException, ClipboardSetupException
 
 
 class XclipClipboard(ClipboardBase):
@@ -94,8 +94,19 @@ class XclipClipboard(ClipboardBase):
                 encoding=encoding,
             )
         else:
+            # retrieve the available targets and selects the first mime type available or plain text. 
+            available_targets = [
+                t for t in subprocess.check_output(args + ['-t', 'TARGETS'], text=True).splitlines() if t.islower()
+            ]
+            if "text/plain" in available_targets:
+                target = ["-t", "text/plain"]
+            elif available_targets:
+                target = ["-t", available_targets[0]]
+            else:
+                target = []
+
             completed_proc = subprocess.run(
-                args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                args + target, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
 
         if completed_proc.returncode != 0:


### PR DESCRIPTION
 This proposal fix a very basic use case in linux. When I capture a screenshot `pyclip` (<kbd>CTRL+PrtScr</kbd> or <kbd>SHIFT+CTRL+PrtScr</kbd> in gnome), the data is in the clipboard but `pyclip`try to paste it as STRING and fail.  Instead I try to parse the available targets and select the best one if it couldn't be pasted as plain/text. 

This is original issue 

```python
In [1]: import pyclip                                                                                                                                         

In [2]: pyclip.paste()                                                                                                                                        
---------------------------------------------------------------------------
ClipboardException                        Traceback (most recent call last)
<ipython-input-2-d18644d9efc4> in <module>
----> 1 pyclip.paste()

~/lab/pyclip/pyclip/__init__.py in paste(*args, **kwargs)
     40     if DEFAULT_CLIPBOARD is None:
     41         raise ClipboardSetupException("Could not setup clipboard").with_traceback(_CLIPBOARD_EXCEPTION_TB)
---> 42     return DEFAULT_CLIPBOARD.paste(*args, **kwargs)
     43 
     44 

~/lab/pyclip/pyclip/xclip_clip.py in paste(self, encoding, text, errors)
    100 
    101         if completed_proc.returncode != 0:
--> 102             raise ClipboardException(
    103                 f"Copy failed. xclip returned code: {completed_proc.returncode!r} "
    104                 f"Stderr: {completed_proc.stderr!r} "

ClipboardException: Copy failed. xclip returned code: 1 Stderr: b'Error: target STRING not available\n' Stdout: b''
In [3]:    
```
and after my patch

```python
In [1]: import pyclip                                                                                                                                         

In [2]: pyclip.paste()                                                                                                                                        
Out[2]: b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00=\x00\x00\x002\x08\x06\x00\x00\x00\xef4\xd3<\x00\x00\x00\x04sBIT\x08\x08\x08\x08|\x08d\x88\x00\x00\x00\x19tEXtSoftware\x00gnome-screenshot\xef\x03\xbf>\x00\x00\x00&tEXtCreation Time\x00vie 22 jul 2022 11:24:59\xa8\xab\xa1\x82\x00\x00\x01\xfcIDATh\x81\xed\x99\xb1K\x1bQ\x18\xc0\x7f\xd7\x1cFkc5\xb5\x1d\x84\x94\xd2\xb1\x8b\xb6\xa2\x82\xd2\xa5\xe0"\xba4vpr\xf2\x0f\xe8\xd0\xa5t).\xfa\x1f\xb8:u\xb0C\xc4\xc9\xcd)\xa0\x83\x82\x85"\xdaR\\TD\x1d\x0c\xa2\xa9\x988\xdc]x\xd6DS?\xcf\x9c|\xef7\xe4\xf8\xbe{\xf9\xf2~w\xef\xbd\xbcK\x1c\xa0\x882\x1e\xd4\xba\x03\xb5\xc0Jk\xc1Jk\xc1Jk\xc1Jk\xc1Jk\xc1Jk\xc1\xadu\x07\xae\xe5\x1d\xd0o\xc4\xab\xc07YI\xb7\xf4:~M\xcb\xaf\xc0\x89\xec\xc3Dd\x81-\xe0\xa0\xfc\xe9\xee\x91V^\xf6$x\xd1\xf5\x88d*\x0e\xc0\xfef\x9e\xc9\xb7?.\xb5\xf5\xa4\x8b\xc0\xb2\x91}\r8\xff\xe4\xce\xe4\xfd\x16\xf1\x1b\xf8Y\xf9\xf4\xe0\x97\x14\xf5\x89XU\xa5<\xe93`\xc6\xc8v\xe0I\xcf\x94yGD)\x16`\xf7\xd7\t\x7f\x96rt\xa6\x9f\xe0\xc6+/W7\x9b\xd3\t\xe03\xb0\x06\xcc\x03\x03\xc0s\xbc\x11\xb3\x06\xccr\xe7Sa\xa2o\x95\xe3Co8\xb6\x0f%q\xe3\x95\xdb\xcaV\xef&`\x0c(\x00+\xc0\x11\xde(I\x8b\xaa\xde\x88@\xb8\x1ad\xabw\x1b\x90\x01\x16\xfd\xb8\x0e\xf8\x04\xbc\x02\xea\xa9\xed\xc2w\x05\xb2;\x9d\x03\x96\x8c\xf8/\xb0\xe1W}*\xaa\x1c*2\xe9=.\xff\x96z\xe4\x1f\xebD\x95CE&\x9d/\x93\x0b.\x82#\xaa\x1c**\xb7\xa1*\xa5\xa3\xbf\xf7\xae\x82\xc6\xa4K\xef\xe8\xb3R\x1clL\x1e6\xbb\xf4\x7fl+\xe5\x17\xa6v8=.\xf8\xd21\xe0\xbdQ%\x98\x8f\x1f\x8c\\\x068\r\xa5\xcfb\x1a[.\xca\x054<\x8e]\xc8g\xa7w\ri\x07xS\xa6\x9a\x99\x9b#\xb2\xd2\xff\x8bC\xd4\xff\xc0\x0b\x1e-\xbf\x03\xebx\x17^\xb8\xe9\xb9?sz\xd8?\xde\xc2\xf3t\xf4\xeft\x12h5\xe2\x1c\xb0-+\x19}\xe9\x10P\xf9=m\xa5\xb5`\xa5\xb5`\xa5\xb5`\xa5\xb5`\xa5\xb5`\xa5\xb5`\xa5\xb5`\xa5\xb5p\x0e\xe7sY\xc5\xe7\xc6\x94]\x00\x00\x00\x00IEND\xaeB`\x82'
```

for tests, It's hard to set real clipboard "targets" programmatically, so I simply mocked the subprocess call and check the paste command suprocess' arguments. 
